### PR TITLE
install netdata on hosts in DMZ, fixes #2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,9 @@ Configuration
 =============
 
 +---------------------------+-----------------------------------------------+
+| ``netdata_dmz``           | if set, will download netdata package through |
+|                           | the ansible host                              |
++---------------------------+-----------------------------------------------+
 | ``netdata_url_base``      | base URL where to download netdata            |
 +---------------------------+-----------------------------------------------+
 | ``netdata_url_latest``    | a file containing the base name               |

--- a/tasks/download_and_install.yml
+++ b/tasks/download_and_install.yml
@@ -1,0 +1,53 @@
+---
+
+- name: 'download and install'
+  block:
+    - name: 'create a temporary file on the host'
+      tempfile:
+        state: "file"
+        suffix: "netdata.gz.run"
+      register: "_netdata_gz_run"
+
+    - name: 'get package: on the ansible machine for when the host does *not* have internet access'
+      when: netdata_dmz is defined and netdata_dmz | bool
+      get_url:
+        url: '{{ netdata_installer_uri }}'
+        dest: '{{ playbook_dir }}/{{ netdata_latest_package }}'
+      run_once: true
+      delegate_to: localhost
+
+    - name: 'get package: upload from ansible machine to host'
+      when: netdata_dmz is defined and netdata_dmz | bool
+      copy:
+        src: '{{ playbook_dir }}/{{ netdata_latest_package }}'
+        dest: '{{ _netdata_gz_run.path }}'
+
+    - name: 'get package: on the host when it *does* have internet access'
+      when: netdata_dmz is not defined or not netdata_dmz | bool
+      get_url:
+        url: '{{ netdata_installer_uri }}'
+        dest: '{{ _netdata_gz_run.path }}'
+        force: true
+
+    - name: 'run the install/upgrade process'
+      command: '/bin/sh {{ _netdata_gz_run.path }} --quiet --accept'
+
+    - name: 'configuration: fetch latest'
+      get_url:
+        url: 'http://localhost:19999/netdata.conf'
+        dest: '/opt/netdata/etc/netdata/netdata.conf'
+        force: true
+
+  when:
+    - not ansible_check_mode
+    - local_netdata_version is not defined
+      or
+      local_netdata_version is version_compare(netdata_latest_version, '<')
+  always:
+    - name: 'remove temporary file'
+      file:
+        path: '{{ _netdata_gz_run.path }}'
+        state: "absent"
+  tags: ['netdata']
+
+...

--- a/tasks/mainstream.yml
+++ b/tasks/mainstream.yml
@@ -69,40 +69,9 @@
   tags:
     - netdata
 
-- name: 'netdata: installation/upgrade'
-  block:
-
-    - tempfile:
-        state: "file"
-        suffix: "netdata.gz.run"
-      register: "netdata_package_local"
-
-    - name: 'netdata: get package'
-      get_url:
-        url: '{{ netdata_installer_uri }}'
-        dest: '{{ netdata_package_local.path }}'
-        force: true
-
-    - name: 'netdata: install/upgrade'
-      command: '/bin/sh {{ netdata_package_local.path }} --quiet --accept'
-
-    - name: 'netdata: configuration: fetch latest'
-      get_url:
-        url: 'http://localhost:19999/netdata.conf'
-        dest: '/opt/netdata/etc/netdata/netdata.conf'
-        force: true
-
-  when:
-    - not ansible_check_mode
-    - local_netdata_version is not defined
-      or
-      local_netdata_version is version_compare(netdata_latest_version, '<')
-  always:
-    - file:
-        path: '{{ netdata_package_local.path }}'
-        state: "absent"
-  tags:
-    - netdata
+- name: 'installation/upgrade'
+  tags: ['netdata']
+  import_tasks: 'download_and_install.yml'
 
 - name: 'configuration: ensure files are present'
   block:


### PR DESCRIPTION
Make it possible to install netdata on hosts without internet,
assuming the ansible host have internet access, eventually through proxy.